### PR TITLE
Make qucsconv accept SPICE syntax for variables

### DIFF
--- a/src/scan_dataset.lpp
+++ b/src/scan_dataset.lpp
@@ -63,8 +63,9 @@ WS       [ \t\n\r]
 IDENT1   [a-zA-Z_][a-zA-Z0-9_]*
 IDENT2   [a-zA-Z_][a-zA-Z0-9_\[\],]*
 IDENT3   [a-zA-Z0-9_][a-zA-Z0-9_]*
+IDENT4   [vViI]\([a-zA-Z0-9_]*\)
 IDENT    {IDENT1}|{IDENT2}
-PIDENT   {IDENT1}|{IDENT2}|{IDENT3}
+PIDENT   {IDENT1}|{IDENT2}|{IDENT3}|{IDENT4}
 SIMPLEID {IDENT}
 POSTID   "."{PIDENT}
 ID       {SIMPLEID}{POSTID}*


### PR DESCRIPTION
This PR fixes #4. The qucsconv is now able to process dataset having SPICE voltage or current variables. 