### PR TITLE
Fix cmake search for fucntions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(qucs-core CXX)
 
+include(CheckSymbolExists)
+include(CheckCXXSymbolExists)
+
 # ignore the project() managed VERSION (new in CMake 3.0)
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 OLD)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,13 +139,11 @@ set(REQUIRED_FUNCTIONS
     trunc
     acosh
     asinh # for real.cpp
-    strdup
-    strerror
-    strchr) # for compat.h, matvec.cpp, scan_*.cpp
+    )
 
 foreach(func ${REQUIRED_FUNCTIONS})
   string(TOUPPER ${func} FNAME)
-  check_function_exists(${func} HAVE_${FNAME})
+  check_cxx_symbol_exists(${func} cmath HAVE_${FNAME})
   # message(STATUS "${func}  --> ${HAVE_${FNAME}}")
 endforeach()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,21 +160,6 @@ endforeach()
 # AC_CHECK_CXX_COMPLEX_POLAR_COMPLEX !failed
 
 #
-# Namespace
-#
-# Check whether the compiler implements namespaces
-#
-try_compile(
-  HAVE_NAMESPACES ${CMAKE_BINARY_DIR}
-  ${qucs-core_SOURCE_DIR}/cmake/namespaces.cpp OUTPUT_VARIABLE TRY_OUT)
-if(NOT HAVE_NAMESPACES)
-  message(
-    SEND_ERROR
-      "${PROJECT_NAME} requires an c++ compiler with namespace HAVE_NAMESPACES failed"
-  ) # ${TRY_OUT}")
-endif()
-
-#
 # Check whether the compiler has complex<T>
 #
 try_compile(HAVE_COMPLEX ${CMAKE_BINARY_DIR}

--- a/src/compat.h
+++ b/src/compat.h
@@ -7,16 +7,16 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this package; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
- * Boston, MA 02110-1301, USA.  
+ * Boston, MA 02110-1301, USA.
  *
  * $Id$
  *
@@ -29,10 +29,6 @@
 # include <ieeefp.h>
 #endif
 
-#if !HAVE_STRCHR
-# define strchr  index
-# define strrchr rindex
-#endif
 
 #if defined(_WIN32) & not defined(__MINGW32__)
 #define strcasecmp stricmp

--- a/src/converter/scan_spice.lpp
+++ b/src/converter/scan_spice.lpp
@@ -50,10 +50,6 @@
 #include "check_spice.h"
 #include "parse_spice.hpp"
 
-#if !HAVE_STRCHR
-# define strchr  index
-# define strrchr rindex
-#endif
 
 /* fixing invalid identifiers */
 static void spice_fix_identifier (char * ident) {

--- a/src/converter/scan_vcd.lpp
+++ b/src/converter/scan_vcd.lpp
@@ -51,10 +51,6 @@
 #include "check_vcd.h"
 #include "parse_vcd.hpp"
 
-#if !HAVE_STRCHR
-# define strchr  index
-# define strrchr rindex
-#endif
 
 %}
 

--- a/src/matvec.cpp
+++ b/src/matvec.cpp
@@ -44,10 +44,6 @@
 #include "matrix.h"
 #include "matvec.h"
 
-#if !HAVE_STRCHR
-# define strchr  index
-# define strrchr rindex
-#endif
 
 namespace qucs {
 

--- a/src/scan_mdl.lpp
+++ b/src/scan_mdl.lpp
@@ -50,10 +50,6 @@
 #include "check_mdl.h"
 #include "parse_mdl.hpp"
 
-#if !HAVE_STRCHR
-# define strchr  index
-# define strrchr rindex
-#endif
 
 using namespace qucs;
 

--- a/src/scan_netlist.lpp
+++ b/src/scan_netlist.lpp
@@ -52,10 +52,6 @@
 #include "check_netlist.h"
 #include "parse_netlist.hpp"
 
-#if !HAVE_STRCHR
-# define strchr  index
-# define strrchr rindex
-#endif
 
 using namespace qucs;
 

--- a/src/scan_zvr.lpp
+++ b/src/scan_zvr.lpp
@@ -50,10 +50,6 @@
 #include "check_zvr.h"
 #include "parse_zvr.hpp"
 
-#if !HAVE_STRCHR
-# define strchr  index
-# define strrchr rindex
-#endif
 
 using namespace qucs;
 


### PR DESCRIPTION
This PR contains the following fixes for CMake:

* The `check_function_exists` replaced by `check_cxx_symbol_exists`
* The check for namespace support has been removed. This check is redundant for C++11 standard 