### PR TITLE
Qucsconv improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ install_manifest.txt
 
 lib/
 lib/gtest/
+build*
+*.user
 
 # generated manual pages
 *.1

--- a/src/converter/parse_spice.ypp
+++ b/src/converter/parse_spice.ypp
@@ -10,16 +10,16 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this package; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
- * Boston, MA 02110-1301, USA.  
+ * Boston, MA 02110-1301, USA.
  *
  * $Id$
  *
@@ -686,7 +686,7 @@ VOLTAGE_Output:
     $$ = NULL;
     $$ = spice_append_str_values ($$, $1, HINT_NAME | HINT_MSTART);
     $$ = spice_append_str_values ($$, $2, HINT_NODE);
-    $$ = spice_append_str_values ($$, $3, HINT_NODE | HINT_MSTOP);    
+    $$ = spice_append_str_values ($$, $3, HINT_NODE | HINT_MSTOP);
   }
 ;
 
@@ -766,6 +766,10 @@ MODEL_List: /* nothing */ { $$ = NULL; }
     $$ = netlist_append_values ($$, $2);
   }
   | Identifier Value MODEL_List {
+    $$ = spice_create_par_value ($1, $2);
+    $$ = netlist_append_values ($$, $3);
+  }
+  | Identifier Identifier MODEL_List {
     $$ = spice_create_par_value ($1, $2);
     $$ = netlist_append_values ($$, $3);
   }

--- a/src/converter/qucs_producer.cpp
+++ b/src/converter/qucs_producer.cpp
@@ -7,16 +7,16 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this package; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
- * Boston, MA 02110-1301, USA.  
+ * Boston, MA 02110-1301, USA.
  *
  * $Id$
  *
@@ -349,7 +349,7 @@ static void qucslib_list_device (struct definition_t * def) {
   if (!(dev = qucslib_find_device (def->type))) return;
   struct pair_t * pair;
   char txt[1024];
-  
+
   sprintf (txt, "\n<Component %s>\n", def->instance[0] == dev->stype[0] ?
 	   &def->instance[1] : def->instance);
   fprintf (qucs_out, "%s", txt);
@@ -371,9 +371,14 @@ static void qucslib_list_device (struct definition_t * def) {
 }
 
 /* This function is the overall Qucs library producer. */
-void qucslib_producer (void) {
+void qucslib_producer (char* libname)
+{
   struct definition_t * def;
-  fprintf (qucs_out, "<Qucs Library " PACKAGE_VERSION " \"Generic\">\n");
+  if (libname == NULL) {
+    fprintf (qucs_out, "<Qucs Library " PACKAGE_VERSION " \"Generic\">\n");
+  } else {
+    fprintf (qucs_out, "<Qucs Library " PACKAGE_VERSION " \"%s\">\n", libname);
+  }
   for (def = device_root; def; def = def->next) {
     qucslib_list_device (def);
   }

--- a/src/converter/qucs_producer.h
+++ b/src/converter/qucs_producer.h
@@ -36,7 +36,7 @@ extern const char * qucs_gnd;
 /* Available functions of the producers. */
 void qucs_producer (void);
 int  qucs_find_node (struct node_t *, char *);
-void qucslib_producer (void);
+void qucslib_producer (char *libname);
 void qucsdata_producer_vcd (void);
 void qucsdata_producer (qucs::dataset *);
 

--- a/src/converter/qucsconv.cpp
+++ b/src/converter/qucsconv.cpp
@@ -60,6 +60,7 @@ struct actionset_t {
 
 /* data variable specification */
 char * data_var = NULL;
+char * lib_name = NULL;
 
 /* required forward declarations */
 int spice2qucs (struct actionset_t *, char *, char *);
@@ -141,6 +142,7 @@ int main (int argc, char ** argv) {
 	"  -a, --noaction  do not include netlist actions in the output\n"
 	"  -g  GNDNODE     replace ground node\n"
 	"  -d  DATANAME    data variable specification\n"
+	"  -ln LIBNAME     define library name; \"Generic\" is default\n"
 	"  -c, --correct   enable node correction\n"
   "\nFORMAT: The input - output format pair should be one of the following:\n"
   "  inputformat - outputformat\n"
@@ -178,6 +180,9 @@ int main (int argc, char ** argv) {
     }
     else if (!strcmp (argv[i], "-d")) {
       if (argv[++i]) data_var = argv[i];
+    }
+    else if (!strcmp (argv[i], "-ln")) {
+      if (argv[++i]) lib_name = argv[i];
     }
     else if (!strcmp (argv[i], "-c") || !strcmp (argv[i], "--correct")) {
       vcd_correct = 1;
@@ -237,7 +242,7 @@ int spice2qucs (struct actionset_t * action, char * infile, char * outfile) {
   if (!strcmp (action->out, "qucs"))
     qucs_producer ();
   else /* "qucslib" */
-    qucslib_producer ();
+    qucslib_producer (lib_name);
   fclose (qucs_out);
   spice_destroy ();
   return 0;


### PR DESCRIPTION
This PR implements the following improvements in converter:

* Added `-ln` option to define the library name for #11 
* Converter don't raise error on string properties in the `.MODEL`. Such properties are simply ignored.  