### PR TITLE
Transient models for simple transmission lines 

### DIFF
--- a/src/components/coaxline.cpp
+++ b/src/components/coaxline.cpp
@@ -167,6 +167,45 @@ void coaxline::calcNoiseAC (nr_double_t) {
   setMatrixN (4 * celsius2kelvin (T) / T0 * real (getMatrixY ()));
 }
 
+void coaxline::initTR (void) {
+  nr_double_t l = getPropertyDouble ("L");
+  nr_double_t er  = getPropertyDouble ("er");
+  nr_double_t mur = getPropertyDouble ("mur");
+
+  calcPropagation(0.0);
+
+  deleteHistory ();
+  if (l > 0.0) {
+    setVoltageSources (2);
+    allocMatrixMNA ();
+    setHistory (true);
+    initHistory (l * qucs::sqrt(er * mur) / C0);
+    setB (NODE_1, VSRC_1, +1); setB (NODE_2, VSRC_2, +1);
+    setC (VSRC_1, NODE_1, +1); setC (VSRC_2, NODE_2, +1);
+    setD (VSRC_1, VSRC_1, -zl); setD (VSRC_2, VSRC_2, -zl);
+  } else {
+    setVoltageSources (1);
+    allocMatrixMNA ();
+    voltageSource (VSRC_1, NODE_1, NODE_2);
+  }
+}
+
+void coaxline::calcTR (nr_double_t t) {
+  nr_double_t l = getPropertyDouble ("L");
+  nr_double_t er  = getPropertyDouble ("er");
+  nr_double_t mur = getPropertyDouble ("mur");
+  nr_double_t T = l  * qucs::sqrt(er * mur) / C0;
+  nr_double_t a = alpha;
+  if (T > 0.0) {
+    T = t - T;
+    a = std::exp (-a / 2 * l);
+    setE (VSRC_1, a * (getV (NODE_2, T) + zl * getJ (VSRC_2, T)));
+    setE (VSRC_2, a * (getV (NODE_1, T) + zl * getJ (VSRC_1, T)));
+  }
+}
+
+
+
 // properties
 PROP_REQ [] = {
   { "D", PROP_REAL, { 2.95e-3, PROP_NO_STR }, PROP_POS_RANGEX },

--- a/src/components/coaxline.h
+++ b/src/components/coaxline.h
@@ -37,6 +37,8 @@ class coaxline : public qucs::circuit
   void calcAC (nr_double_t);
   void calcNoiseAC (nr_double_t);
   void saveCharacteristics (nr_double_t);
+  void initTR();
+  void calcTR(nr_double_t);
 
  private:
   void calcPropagation (nr_double_t);

--- a/src/components/microstrip/msline.cpp
+++ b/src/components/microstrip/msline.cpp
@@ -73,11 +73,11 @@ void msline::calcPropagation (nr_double_t frequency) {
 
   // analyse dispersion of Zl and Er (use WEff here?)
   analyseDispersion (W, h, er, ZlEff, ErEff, frequency, DModel,
-		     ZlEffFreq, ErEffFreq);
+                ZlEffFreq, ErEffFreq);
 
   // analyse losses of line
   analyseLoss (W, t, er, rho, D, tand, ZlEff, ZlEff, ErEff,
-	       frequency, "Hammerstad", ac, ad);
+          frequency, "Hammerstad", ac, ad);
 
   // calculate propagation constants and reference impedance
   zl    = ZlEffFreq;
@@ -484,6 +484,42 @@ void msline::calcNoiseAC (nr_double_t) {
   nr_double_t T = getPropertyDouble ("Temp");
   setMatrixN (4 * celsius2kelvin (T) / T0 * real (getMatrixY ()));
 }
+
+
+void msline::initTR (void) {
+  nr_double_t l = getPropertyDouble ("L");
+
+  calcPropagation(0.0);
+
+  deleteHistory ();
+  if (l > 0.0) {
+    setVoltageSources (2);
+    allocMatrixMNA ();
+    setHistory (true);
+    initHistory (l * qucs::sqrt(ereff) / C0);
+    setB (NODE_1, VSRC_1, +1); setB (NODE_2, VSRC_2, +1);
+    setC (VSRC_1, NODE_1, +1); setC (VSRC_2, NODE_2, +1);
+    setD (VSRC_1, VSRC_1, -zl); setD (VSRC_2, VSRC_2, -zl);
+  } else {
+    setVoltageSources (1);
+    allocMatrixMNA ();
+    voltageSource (VSRC_1, NODE_1, NODE_2);
+  }
+}
+
+void msline::calcTR (nr_double_t t) {
+  nr_double_t l = getPropertyDouble ("L");
+  nr_double_t T = l  * qucs::sqrt(ereff) / C0;
+  nr_double_t a = alpha;
+  if (T > 0.0) {
+    T = t - T;
+    a = std::exp (-a / 2 * l);
+    setE (VSRC_1, a * (getV (NODE_2, T) + zl * getJ (VSRC_2, T)));
+    setE (VSRC_2, a * (getV (NODE_1, T) + zl * getJ (VSRC_1, T)));
+  }
+}
+
+
 
 // properties
 PROP_REQ [] = {

--- a/src/components/microstrip/msline.h
+++ b/src/components/microstrip/msline.h
@@ -37,6 +37,8 @@ class msline : public qucs::circuit
   void calcAC (nr_double_t);
   void calcNoiseAC (nr_double_t);
   void saveCharacteristics (nr_double_t);
+  void initTR();
+  void calcTR(nr_double_t);
 
   static void analyseQuasiStatic (nr_double_t, nr_double_t, nr_double_t,
 				  nr_double_t, const char * const,


### PR DESCRIPTION
This PR implements basic transient models for simple transmision lines. The list of devices with added model:

* Microstrip line
* Coaxial line

Here is a test schematic in Qucs-S GUI. The TRAN model for coupled lines is not implemented. The help is appreciated here.

Limitation of the models:

* The ripple on the pulse edges are not calculated. The existing models for ideal TLine also don't calculate ripple. 
* It's unclear how to calculate losses. The losses for MS lines are derived from a fixed frequency which is unknown for transient. 

![image](https://github.com/user-attachments/assets/0ed1bf89-606c-484f-a93d-df30790ae43a)
