### PR TITLE
Simple TRAN models for mscorner, msmbend and bonwire

### DIFF
--- a/src/components/microstrip/bondwire.cpp
+++ b/src/components/microstrip/bondwire.cpp
@@ -386,6 +386,11 @@ void bondwire::initDC (void) {
   }
 }
 
+void bondwire::initTR (void)
+{
+  initDC();
+}
+
 /*! Initialize AC simulation. */
 void bondwire::initAC (void) {
   getProperties ();
@@ -398,6 +403,20 @@ void bondwire::initAC (void) {
  */
 void bondwire::calcAC (const nr_double_t frequency) {
   setMatrixY (calcMatrixY (frequency));
+}
+
+void bondwire::calcDC(void)
+{
+  if (rho != 0.0) {
+    nr_double_t g = 1.0 / resistance (0);
+    setY (NODE_1, NODE_1, +g); setY (NODE_2, NODE_2, +g);
+    setY (NODE_1, NODE_2, -g); setY (NODE_2, NODE_1, -g);
+  }
+}
+
+void bondwire::calcTR(nr_double_t t)
+{
+  calcDC();
 }
 
 void bondwire::calcNoiseSP (nr_double_t) {

--- a/src/components/microstrip/bondwire.h
+++ b/src/components/microstrip/bondwire.h
@@ -36,7 +36,10 @@ class bondwire : public qucs::circuit
   void calcNoiseSP (nr_double_t);
   void initDC (void);
   void initAC (void);
+  void initTR (void);
+  void calcDC (void);
   void calcAC (nr_double_t);
+  void calcTR (nr_double_t);
   void calcNoiseAC (nr_double_t);
   qucs::matrix calcMatrixY (nr_double_t);
   void saveCharacteristics (nr_double_t);

--- a/src/components/microstrip/mscorner.cpp
+++ b/src/components/microstrip/mscorner.cpp
@@ -105,6 +105,11 @@ void mscorner::initAC (void) {
   initCheck ();
 }
 
+void mscorner::initTR(void)
+{
+  initDC();
+}
+
 void mscorner::calcAC (nr_double_t frequency) {
   setMatrixY (ztoy (calcMatrixZ (frequency)));
 }

--- a/src/components/microstrip/mscorner.h
+++ b/src/components/microstrip/mscorner.h
@@ -34,6 +34,7 @@ class mscorner : public qucs::circuit
   void initSP (void);
   void initDC (void);
   void initAC (void);
+  void initTR (void);
   void calcAC (nr_double_t);
 
  private:

--- a/src/components/microstrip/msmbend.cpp
+++ b/src/components/microstrip/msmbend.cpp
@@ -99,6 +99,11 @@ void msmbend::initAC (void) {
   allocMatrixMNA ();
 }
 
+void msmbend::initTR (void)
+{
+  initDC();
+}
+
 void msmbend::calcAC (nr_double_t frequency) {
   setMatrixY (ztoy (calcMatrixZ (frequency)));
 }

--- a/src/components/microstrip/msmbend.h
+++ b/src/components/microstrip/msmbend.h
@@ -33,6 +33,7 @@ class msmbend : public qucs::circuit
   void calcSP (nr_double_t);
   void initDC (void);
   void initAC (void);
+  void initTR (void);
   void calcAC (nr_double_t);
   qucs::matrix calcMatrixZ (nr_double_t);
 };


### PR DESCRIPTION
I have recently noticed that mscross device has simple TRAN model, but mscorner, msmbend and bondwire have no TRAN model. This PR implements the following models:

* msmbend and mscorner simulated as short circuit for TRAN. The mscross has the same model.
* bondwire is simulated not taking into account skin-effect 


![image](https://github.com/user-attachments/assets/eca64cdd-1c59-49da-85c9-c92d76261885)

