### PR TITLE
Fix u_even, u_odd calculation for mscouple

### DIFF
--- a/src/components/microstrip/mscoupled.h
+++ b/src/components/microstrip/mscoupled.h
@@ -43,7 +43,7 @@ class mscoupled : public qucs::circuit
 				 nr_double_t&, nr_double_t&, nr_double_t&,
 				 nr_double_t&);
   static void analyseDispersion (nr_double_t, nr_double_t, nr_double_t,
-				 nr_double_t, nr_double_t, nr_double_t,
+				 nr_double_t, nr_double_t, nr_double_t, nr_double_t,
 				 nr_double_t, nr_double_t, nr_double_t, const char * const,
 				 nr_double_t&, nr_double_t&, nr_double_t&,
 				 nr_double_t&);


### PR DESCRIPTION
This issue was reported by some Qucs user by e-mail. The equations in effection width calulation for  `mscouple::anyalyseDispersion` have mistake. Compare to the equations in the Puff software source: https://web.archive.org/web/20170507045658/http://www.its.caltech.edu/~mmic/puffindex/puffE/puffE.htm This PR fixes the equations. 