### PR TITLE
Fix equations in rectline

### DIFF
--- a/src/components/rectline.cpp
+++ b/src/components/rectline.cpp
@@ -192,9 +192,9 @@ void rectline::calcPropagation (nr_double_t frequency) {
   } else {
     /* according to [2] eq 3.207 */
     beta = 0;
-    alpha = -std::sqrt (- (sqr (k0) - sqr (kc)));
+    alpha = std::sqrt (- (sqr (k0) - sqr (kc)));
     // wave impedance
-    zl = (k0 * Z0 * std::sqrt(mur/er)) / nr_complex_t (0, -alpha) ;
+    zl = (k0 * Z0 * std::sqrt(mur/er)) / nr_complex_t (0, alpha) ;
   }
 }
 


### PR DESCRIPTION
This issue was reported by e-mail. The alpha factor in `rectline::calcPropagation` must be positive. Compare to the same equations in circular waveguide model `circline.cpp`. 