### PR TITLE
Fix https://github.com/ra3xdh/qucs_s/issues/967:

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,10 @@ foreach(type ${ParserTypes})
       ${BISON_EXECUTABLE}
       --defines=parse_${type}.hpp
       --output=parse_${type}.cpp
+      -v
+      -Wce
+      -Wprecedence
+      -Wmidrule-value
       ${bisonIn}
     DEPENDS ${bisonIn})
   # Create custom Flex

--- a/src/check_citi.cpp
+++ b/src/check_citi.cpp
@@ -89,8 +89,7 @@ static char * citi_get_package (struct citi_package_t * p) {
 }
 
 /* Create a valid vector for the dataset. */
-static qucs::vector * citi_create_vector (struct citi_package_t * p, int i,
-				    char * n, char * type) {
+static qucs::vector * citi_create_vector (struct citi_package_t * p, int i, char * n, char * type) {
   qucs::vector * vec;
   vec = citi_get_vector (p, i); // fetch vector
   vec = new qucs::vector (*vec);      // copy vector
@@ -195,8 +194,8 @@ int citi_check (void) {
     int cvar = citi_count_variables (p);
     if (cvec != cvar) {
       logprint (LOG_ERROR, "checker error, no. of vectors (%d) does not equal "
-		"no. of variables (%d) in package `%s'\n", cvec, cvar,
-		package);
+        "no. of variables (%d) in package `%s'\n", cvec, cvar,
+        package);
       errors++;
       break;
     }
@@ -213,50 +212,50 @@ int citi_check (void) {
     for (h = p->head; h != NULL; h = h->next) {
       qucs::vector * v;
       if (h->var != NULL) {
-	char txt[256];
-	if (h->i1 >= 0) {
-	  /* dependent variables */
-	  if (h->i2 >= 0) {
-	    sprintf (txt, "%s%s[%d,%d]", opack, h->var, h->i1, h->i2);
-	    v = citi_create_vector (p, n, txt, h->type);
-	    v->setDependencies (new strlist (deps));
-	    errors += citi_check_dep_length (v, deps, package);
-	    citi_result->addVariable (v);
-	    n++;
-	  } else {
-	    sprintf (txt, "%s%s[%d]", opack, h->var, h->i1);
-	    v = citi_create_vector (p, n, txt, h->type);
-	    v->setDependencies (new strlist (deps));
-	    errors += citi_check_dep_length (v, deps, package);
-	    citi_result->addVariable (v);
-	    n++;
-	  }
-	} else if (h->n >= 0) {
-	  /* independent variable */
-	  sprintf (txt, "%s%s", opack, h->var);
-	  v = citi_create_vector (p, n, txt, h->type);
-	  deps.add (txt);
-	  if (!citi_result->findDependency (txt)) {
-	    /* add independent vectors only once */
-	    citi_result->addDependency (v);
-	  }
-	  n++;
-	  // check length of independent vector
-	  if (v->getSize () != h->n) {
-	    logprint (LOG_ERROR, "checker error, vector `%s' length (%d) "
-		      "does not equal defined length (%d) in package `%s'\n",
-		      h->var, v->getSize (), h->n, package);
-	    errors++;
-	  }
-	} else {
-	  /* dependent variables, no indices */
-	  sprintf (txt, "%s%s", opack, h->var);
-	  v = citi_create_vector (p, n, txt, h->type);
-	  v->setDependencies (new strlist (deps));
-	  errors += citi_check_dep_length (v, deps, package);
-	  citi_result->addVariable (v);
-	  n++;
-	}
+        char txt[sizeof(opack) + 16];
+        if (h->i1 >= 0) {
+          /* dependent variables */
+          if (h->i2 >= 0) {
+            sprintf (txt, "%s%s[%d,%d]", opack, h->var, h->i1, h->i2);
+            v = citi_create_vector (p, n, txt, h->type);
+            v->setDependencies (new strlist (deps));
+            errors += citi_check_dep_length (v, deps, package);
+            citi_result->addVariable (v);
+            n++;
+          } else {
+            sprintf (txt, "%s%s[%d]", opack, h->var, h->i1);
+            v = citi_create_vector (p, n, txt, h->type);
+            v->setDependencies (new strlist (deps));
+            errors += citi_check_dep_length (v, deps, package);
+            citi_result->addVariable (v);
+            n++;
+          }
+        } else if (h->n >= 0) {
+          /* independent variable */
+          sprintf (txt, "%s%s", opack, h->var);
+          v = citi_create_vector (p, n, txt, h->type);
+          deps.add (txt);
+          if (!citi_result->findDependency (txt)) {
+            /* add independent vectors only once */
+            citi_result->addDependency (v);
+          }
+          n++;
+          // check length of independent vector
+          if (v->getSize () != h->n) {
+            logprint (LOG_ERROR, "checker error, vector `%s' length (%d) "
+              "does not equal defined length (%d) in package `%s'\n",
+              h->var, v->getSize (), h->n, package);
+            errors++;
+          }
+        } else {
+          /* dependent variables, no indices */
+          sprintf (txt, "%s%s", opack, h->var);
+          v = citi_create_vector (p, n, txt, h->type);
+          v->setDependencies (new strlist (deps));
+          errors += citi_check_dep_length (v, deps, package);
+          citi_result->addVariable (v);
+          n++;
+        }
       }
     }
   }

--- a/src/check_mdl.cpp
+++ b/src/check_mdl.cpp
@@ -346,7 +346,7 @@ valuelist<int> * mdl_find_depdataset (struct mdl_link_t * link,
       else if (!strcmp (hyptab->name, "List Table")) {
 	lstsweep * sw = new lstsweep ();
 	sw->create (nof);
-	char txt[16];
+	char txt[32];
 	for (int i = 0; i < nof; i++) {
 	  sprintf (txt, "Value %d", i + 1);
 	  val = mdl_helement_dvalue (link, hyptab->data, txt);
@@ -418,7 +418,7 @@ static void mdl_find_varlink (struct mdl_link_t * link, char * name,
 // Sorts a dependency list according to their sweep order.
 static strlist * mdl_sort_deps (valuelist<int> * d) {
   strlist * deps = new strlist ();
-  for (int i = 0; i < d->size(); i++) {
+  for (int i = 0; i < static_cast<int>(d->size()); i++) {
     for (auto &val: *d) {
       if (val.second == i + 1) {
 	deps->append (val.first.c_str());

--- a/src/circuit.cpp
+++ b/src/circuit.cpp
@@ -229,22 +229,22 @@ void circuit::freeMatrixHB (void) {
 /* Allocates the HB-matrix memory. */
 void circuit::allocMatrixHB (void) {
   if (VectorQ) {
-    memset (VectorQ, 0, size * sizeof (nr_complex_t));
+    memset (static_cast<void*>(VectorQ), 0, size * sizeof (nr_complex_t));
   } else {
     VectorQ = new nr_complex_t[size];
   }
   if (MatrixQV) {
-    memset (MatrixQV, 0, size * size * sizeof (nr_complex_t));
+    memset (static_cast<void*>(MatrixQV), 0, size * size * sizeof (nr_complex_t));
   } else {
     MatrixQV = new nr_complex_t[size * size];
   }
   if (VectorCV) {
-    memset (VectorCV, 0, size * sizeof (nr_complex_t));
+    memset (static_cast<void*>(VectorCV), 0, size * sizeof (nr_complex_t));
   } else {
     VectorCV = new nr_complex_t[size];
   }
   if (VectorGV) {
-    memset (VectorGV, 0, size * sizeof (nr_complex_t));
+    memset (static_cast<void*>(VectorGV), 0, size * sizeof (nr_complex_t));
   } else {
     VectorGV = new nr_complex_t[size];
   }
@@ -253,7 +253,7 @@ void circuit::allocMatrixHB (void) {
 /* Allocates the S-parameter matrix memory. */
 void circuit::allocMatrixS (void) {
   if (MatrixS) {
-    memset (MatrixS, 0, size * size * sizeof (nr_complex_t));
+    memset (static_cast<void*>(MatrixS), 0, size * size * sizeof (nr_complex_t));
   } else {
     MatrixS = new nr_complex_t[size * size];
   }
@@ -654,8 +654,8 @@ void circuit::setMatrixS (matrix s) {
    circuit. */
 matrix circuit::getMatrixS (void) {
   matrix res (size);
-  for(unsigned int i=0; i < size; ++i)
-    for(unsigned int j=0; j < size; ++j)
+  for(int i=0; i < size; ++i)
+    for(int j=0; j < size; ++j)
       res(i,j) = MatrixS[i*size + j];
   return res;
 }
@@ -675,8 +675,8 @@ void circuit::setMatrixN (matrix n) {
    matrix of the circuit. */
 matrix circuit::getMatrixN (void) {
   matrix res (size);
-  for(unsigned int i=0; i < size; ++i)
-    for(unsigned int j=0; j < size; ++j)
+  for(int i=0; i < size; ++i)
+    for(int j=0; j < size; ++j)
       res(i,j) = MatrixN[i*size + j];
   return res;
 }
@@ -696,50 +696,50 @@ void circuit::setMatrixY (matrix y) {
    circuit. */
 matrix circuit::getMatrixY (void) {
   matrix res (size);
-  for(unsigned int i=0; i < size; ++i)
-    for(unsigned int j=0; j < size; ++j)
+  for(int i=0; i < size; ++i)
+    for(int j=0; j < size; ++j)
       res(i,j) = MatrixY[i*size + j];
   return res;
 }
 
 // The function cleans up the B-MNA matrix entries.
 void circuit::clearB (void) {
-  memset (MatrixB, 0, sizeof (nr_complex_t) * size * vsources);
+  memset (static_cast<void*>(MatrixB), 0, sizeof (nr_complex_t) * size * vsources);
 }
 
 // The function cleans up the C-MNA matrix entries.
 void circuit::clearC (void) {
-  memset (MatrixC, 0, sizeof (nr_complex_t) * size * vsources);
+  memset (static_cast<void*>(MatrixC), 0, sizeof (nr_complex_t) * size * vsources);
 }
 
 // The function cleans up the D-MNA matrix entries.
 void circuit::clearD (void) {
-  memset (MatrixD, 0, sizeof (nr_complex_t) * vsources * vsources);
+  memset (static_cast<void*>(MatrixD), 0, sizeof (nr_complex_t) * vsources * vsources);
 }
 
 // The function cleans up the E-MNA matrix entries.
 void circuit::clearE (void) {
-  memset (VectorE, 0, sizeof (nr_complex_t) * vsources);
+  memset (static_cast<void*>(VectorE), 0, sizeof (nr_complex_t) * vsources);
 }
 
 // The function cleans up the J-MNA matrix entries.
 void circuit::clearJ (void) {
-  memset (VectorJ, 0, sizeof (nr_complex_t) * vsources);
+  memset (static_cast<void*>(VectorJ), 0, sizeof (nr_complex_t) * vsources);
 }
 
 // The function cleans up the I-MNA matrix entries.
 void circuit::clearI (void) {
-  memset (VectorI, 0, sizeof (nr_complex_t) * size);
+  memset (static_cast<void*>(VectorI), 0, sizeof (nr_complex_t) * size);
 }
 
 // The function cleans up the V-MNA matrix entries.
 void circuit::clearV (void) {
-  memset (VectorV, 0, sizeof (nr_complex_t) * size);
+  memset (static_cast<void*>(VectorV), 0, sizeof (nr_complex_t) * size);
 }
 
 // The function cleans up the G-MNA matrix entries.
 void circuit::clearY (void) {
-  memset (MatrixY, 0, sizeof (nr_complex_t) * size * size);
+  memset (static_cast<void*>(MatrixY), 0, sizeof (nr_complex_t) * size * size);
 }
 
 /* This function can be used by several components in order to place

--- a/src/components/devices/thyristor.cpp
+++ b/src/components/devices/thyristor.cpp
@@ -85,7 +85,7 @@ void thyristor::calcTheModel (bool last) {
     isOn = Ud > Ud_bo;
 
   nr_double_t Vak = real (getV (NODE_A1) - getV (NODE_A2));
-  isOn *= (Vak > 0.0);
+  isOn &= (Vak > 0.0);
 
   if (Ud >= 80.0) {
     Id *= std::exp (80.0) * (1.0 + Ud - 80.0) - 1.0;

--- a/src/components/microstrip/bondwire.cpp
+++ b/src/components/microstrip/bondwire.cpp
@@ -414,7 +414,7 @@ void bondwire::calcDC(void)
   }
 }
 
-void bondwire::calcTR(nr_double_t t)
+void bondwire::calcTR()
 {
   calcDC();
 }

--- a/src/components/microstrip/bondwire.h
+++ b/src/components/microstrip/bondwire.h
@@ -39,7 +39,7 @@ class bondwire : public qucs::circuit
   void initTR (void);
   void calcDC (void);
   void calcAC (nr_double_t);
-  void calcTR (nr_double_t);
+  void calcTR ();
   void calcNoiseAC (nr_double_t);
   qucs::matrix calcMatrixY (nr_double_t);
   void saveCharacteristics (nr_double_t);

--- a/src/converter/CMakeLists.txt
+++ b/src/converter/CMakeLists.txt
@@ -26,6 +26,10 @@ foreach(type ${ParserTypes})
       ${BISON_EXECUTABLE}
       --defines=parse_${type}.hpp
       --output=parse_${type}.cpp
+      -v
+      -Wce
+      -Wprecedence
+      -Wmidrule-value
       ${bisonIn}
     DEPENDS ${bisonIn})
   # Create custom Flex

--- a/src/converter/check_spice.cpp
+++ b/src/converter/check_spice.cpp
@@ -858,7 +858,7 @@ static void spice_translate_nodes (struct definition_t * def, int pass) {
 	  node->node = strdup (t->node);
 	else {
 	  // no node given, occurs in device descriptions
-	  char txt[16];
+	  char txt[17];
 	  sprintf (txt, "%s%d", "_node", n);
 	  node->node = strdup (txt);
 	}

--- a/src/converter/parse_spice.ypp
+++ b/src/converter/parse_spice.ypp
@@ -44,6 +44,14 @@
 
 #include "check_spice.h"
 
+#define YY_HEADER_EXPORT_START_CONDITIONS
+#include "scan_spice.hpp"
+
+extern char* spice_text;
+
+extern void push_state(int state);
+extern void pop_state();
+
 // Converts the given string into upper case.
 static char * spice_toupper (char * str) {
   for (unsigned int i = 0; i < strlen (str); i++) {
@@ -128,10 +136,11 @@ static struct value_t * spice_append_val_values (struct value_t * values,
 
 %}
 
-%name-prefix "spice_"
+%define api.prefix {spice_}
 
 %token TitleLine InvalidCharacter End Eol
-%token Identifier Digits Floats Nodes Options Function
+%token Identifier Digits Floats Nodes Options Function Lookahead_Double_Value
+%token Lookahead_Three_Node Lookahead_Four_Node Lookahead_Five_Node
 %token SUBCKT_Action ENDS_Action AC_Action OP_Action I_Source SAVE_Action
 %token RLC_Device L_Device K_Device IV_Source GE_Source FH_Source V_Source
 %token Diode_Device Bipolar_Device JFET_Device MOSFET_Device MESFET_Device
@@ -142,6 +151,9 @@ static struct value_t * spice_append_val_values (struct value_t * values,
 %token DISTO_Action INCLUDE_Action File BranchFunc NODESET_Action T_Device
 %token U_Device S_Device W_Device ON_Special TF_Action SENS_Action FOUR_Action
 %token OpFunc Behave TC_Special TEMP_Action
+
+%precedence Identifier Digits Nodes
+%precedence _NODE_
 
 %union {
   char * ident;
@@ -162,7 +174,7 @@ static struct value_t * spice_append_val_values (struct value_t * values,
 %type <value> IC_Condition_4 SWITCH_State NodeValueList TC_Value_1 TC_Value_2
 %type <value> VSourceList
 
-%type <ident> Identifier Nodes Function Value Floats Digits Node FH_Node
+%type <ident> Identifier Nodes Function Value Lookahead_Double_Value Floats Digits Node FH_Node
 %type <ident> RLC_Device K_Device L_Device IV_Source GE_Source FH_Source
 %type <ident> V_Source MODEL_Spec Diode_Device Bipolar_Device JFET_Device
 %type <ident> MOSFET_Device MESFET_Device TRAN_Action PLOT_Action MODEL_Action
@@ -174,7 +186,7 @@ static struct value_t * spice_append_val_values (struct value_t * values,
 %type <ident> IC_Special OFF_Special SIM_Type TEMP_Special MOS_Special
 %type <ident> BranchFunc NODESET_Action T_Device U_Device S_Device W_Device
 %type <ident> TF_Action SENS_Action FOUR_Action OpFunc TC_Special TEMP_Action
-%type <ident> Behave
+%type <ident> Behave Lookahead_Three_Node Lookahead_Four_Node Lookahead_Five_Node
 
 %%
 
@@ -374,7 +386,7 @@ DefinitionLine:
     spice_append_str_value ($$, $5, HINT_NAME);
     $$->values = netlist_append_values ($$->values, $6);
   }
-  | Bipolar_Device Node Node Node MODEL_Ident DEVICE_List_2 {
+  | Bipolar_Device Lookahead_Three_Node Node Node MODEL_Ident DEVICE_List_2 {
     /* 3 node BJT */
     $$ = spice_create_device ($1);
     spice_append_str_value ($$, $2, HINT_NODE);
@@ -383,7 +395,7 @@ DefinitionLine:
     spice_append_str_value ($$, $5, HINT_NAME);
     $$->values = netlist_append_values ($$->values, $6);
   }
-  | Bipolar_Device Node Node Node Node MODEL_Ident DEVICE_List_2 {
+  | Bipolar_Device Lookahead_Four_Node Node Node Node MODEL_Ident DEVICE_List_2 {
     /* 4 node BJT */
     $$ = spice_create_device ($1);
     spice_append_str_value ($$, $2, HINT_NODE);
@@ -393,7 +405,7 @@ DefinitionLine:
     spice_append_str_value ($$, $6, HINT_NAME);
     $$->values = netlist_append_values ($$->values, $7);
   }
-  | Bipolar_Device Node Node Node Node Node MODEL_Ident DEVICE_List_2 {
+  | Bipolar_Device Lookahead_Five_Node Node Node Node Node MODEL_Ident DEVICE_List_2 {
     /* 5 node BJT */
     $$ = spice_create_device ($1);
     spice_append_str_value ($$, $2, HINT_NODE);
@@ -661,7 +673,7 @@ IC_Condition_4:
 ;
 
 Output_Range:
-  Value Value { /* range specification during plotting */
+  Lookahead_Double_Value Value { /* range specification during plotting */
     $$ = NULL;
     $$ = spice_append_val_values ($$, $1, HINT_NUMBER);
     $$ = spice_append_val_values ($$, $2, HINT_NUMBER);
@@ -669,13 +681,14 @@ Output_Range:
 ;
 
 VOLTAGE_Output:
-  Node { // TODO: 2 reduce/reduce, 2 shift/reduce
+  Node {
     /* print/plot specification of node voltage */
+    push_state(DOUBLEVALUE);
     $$ = NULL;
     $$ = spice_append_str_values ($$, strdup ("V"), HINT_NAME | HINT_MSTART);
     $$ = spice_append_str_values ($$, $1, HINT_NODE | HINT_MSTOP);
   }
-  | VoltFunc Node { // TODO: 2 reduce/reduce
+  | VoltFunc Node %prec _NODE_ {
     /* print/plot specification of node voltage */
     $$ = NULL;
     $$ = spice_append_str_values ($$, $1, HINT_NAME | HINT_MSTART);
@@ -843,7 +856,7 @@ DEVICE_List_3: /* nothing */ { $$ = NULL; }
     $$ = netlist_append_values ($$, $2);
   }
   | IC_Condition_3 DEVICE_List_3 {
-    $$ = netlist_append_values ($1, $2);
+     $$ = netlist_append_values ($1, $2);
   }
 ;
 
@@ -969,6 +982,6 @@ SubBodyLine:
 %%
 
 int spice_error (const char * error) {
-  fprintf (stderr, "line %d: %s\n", spice_lineno, error);
+  fprintf (stderr, "line %d: %s at id %d, token '%s'\n", spice_lineno, error, spice_char, spice_text);
   return 0;
 }

--- a/src/converter/parse_vcd.ypp
+++ b/src/converter/parse_vcd.ypp
@@ -43,7 +43,7 @@
 
 %}
 
-%name-prefix "vcd_"
+%define api.prefix {vcd_}
 
 %token t_END
 %token t_COMMENT
@@ -91,7 +91,7 @@
 }
 
 %type <ident> Identifier IdentifierCode Reference
-%type <value> Value ZERO ONE Z X Binary Real
+%type <value> Value ZERO ONE Z Binary Real U
 %type <integer> Size PositiveInteger TimeScale
 %type <real> TimeUnit SimulationTime PositiveHugeInteger
 %type <change> ScalarValueChange VectorValueChange ValueChangeList ValueChange

--- a/src/converter/scan_spice.lpp
+++ b/src/converter/scan_spice.lpp
@@ -50,7 +50,6 @@
 #include "check_spice.h"
 #include "parse_spice.hpp"
 
-
 /* fixing invalid identifiers */
 static void spice_fix_identifier (char * ident) {
   char * p;
@@ -62,9 +61,25 @@ static void spice_fix_identifier (char * ident) {
     }
 }
 
+static void yy_push_state(int);
+static void yy_pop_state();
+static int yy_top_state();
+
+void push_state(int state) {
+    yy_push_state(state);
+}
+
+void pop_state() {
+    yy_pop_state();
+}
+
+int top_state() {
+    return yy_top_state();
+}
+
 %}
 
-WS       [ \t\n\r]
+WS       [ \t]
 TITLE    [* \t0-9A-Za-z][A-Za-z0-9\- \t;#:=()/\.,*\\]*\r*\n
 SPACE    [ \t]
 NAME     [A-Z][A-Z0-9]*
@@ -134,8 +149,8 @@ POLY     [pP][oO][lL][yY]
 
 %x COMMENT IVREF DEVPROP LREF MODREF1 MODREF2 IGNORE FUNREF FILEREF VREF
 %x STARTUP VSINGLE ISWITCH VSWITCH CONTROL GEVALS INLINE SUBCKT TLPROP RLCPROP
-%x FHVALS
-%option yylineno noyywrap nounput noinput prefix="spice_"
+%x FHVALS DOUBLEVALUE LANODE
+%option yylineno stack noyywrap nounput noinput prefix="spice_" header-file="scan_spice.hpp"
 %%
 
 <INITIAL>^{TITLE} { /* detect initial title lines */
@@ -499,6 +514,7 @@ POLY     [pP][oO][lL][yY]
 <STARTUP>^[qQ]{CSFX} { /* BJT instances */
     spice_lval.ident = strdup (spice_text);
     BEGIN(DEVPROP);
+    push_state(LANODE);
     return Bipolar_Device;
 }
 
@@ -524,17 +540,51 @@ POLY     [pP][oO][lL][yY]
     return End;
 }
 
+<DOUBLEVALUE>{NUMBER}|{DIGIT}+/{WS}({DIGIT}+|NUMBER) {
+    /* identify value followed by value */
+    spice_lval.ident = strdup (spice_text);
+    pop_state();
+    return Lookahead_Double_Value;
+}
+
+<LANODE>{NODE}|{IDENT}|{DIGIT}+/{WS}+({DIGIT}+|{NODE}|{IDENT}){WS}+({DIGIT}+|{NODE}|{IDENT}){WS}+({MODEL}|{IDENT}) {
+    /* identify node followed by 2 node */
+    spice_lval.ident = strdup (spice_text);
+    pop_state();
+    return Lookahead_Three_Node;
+}
+
+<LANODE>{NODE}|{IDENT}|{DIGIT}+/{WS}+({DIGIT}+|{NODE}|{IDENT}){WS}+({DIGIT}+|{NODE}|{IDENT}){WS}+({DIGIT}+|{NODE}|{IDENT}){WS}+({MODEL}|{IDENT}) {
+    /* identify node followed by 3 node */
+    spice_lval.ident = strdup (spice_text);
+    pop_state();
+    return Lookahead_Four_Node;
+}
+
+<LANODE>{NODE}|{IDENT}|{DIGIT}+/{WS}+({DIGIT}+|{NODE}|{IDENT}){WS}+({DIGIT}+|{NODE}|{IDENT}){WS}+({DIGIT}+|{NODE}|{IDENT}){WS}+({DIGIT}+|{NODE}|{IDENT}){WS}+({MODEL}|{IDENT}) {
+    /* identify node followed by 4 node */
+    spice_lval.ident = strdup (spice_text);
+    pop_state();
+    return Lookahead_Five_Node;
+}
+
 <STARTUP,IVREF,DEVPROP,LREF,FUNREF,VREF,VSINGLE,ISWITCH,VSWITCH,
- GEVALS,TLPROP,RLCPROP,FHVALS>{DIGIT}+ {
+ GEVALS,TLPROP,RLCPROP,FHVALS,DOUBLEVALUE>{DIGIT}+ {
     /* identify node (containing digits) */
     spice_lval.ident = strdup (spice_text);
+    if (yy_start_stack_ptr > 0 && top_state() == DOUBLEVALUE) {
+      pop_state();
+    }
     return Digits;
 }
 
 <STARTUP,IVREF,DEVPROP,LREF,FUNREF,VREF,VSINGLE,GEVALS,TLPROP,
- RLCPROP,FHVALS>{NUMBER} {
+ RLCPROP,FHVALS,DOUBLEVALUE>{NUMBER} {
     /* identify float (any kind) */
     spice_lval.ident = strdup (spice_text);
+    if (yy_start_stack_ptr > 0 && top_state() == DOUBLEVALUE) {
+      pop_state();
+    }
     return Floats;
 }
 
@@ -563,9 +613,12 @@ POLY     [pP][oO][lL][yY]
 }
 
 <STARTUP,DEVPROP,MODREF2,ISWITCH,VSWITCH,
- TLPROP,RLCPROP>{IDENT} { /* arbitrary identifier */
+ TLPROP,RLCPROP,DOUBLEVALUE>{IDENT} { /* arbitrary identifier */
     spice_lval.ident = strdup (spice_text);
     spice_fix_identifier (spice_lval.ident);
+    if (yy_start_stack_ptr > 0 && top_state() == DOUBLEVALUE) {
+      pop_state();
+    }
     return Identifier;
 }
 
@@ -596,15 +649,21 @@ POLY     [pP][oO][lL][yY]
 }
 
 <STARTUP,IVREF,DEVPROP,FUNREF,VREF,VSINGLE,ISWITCH,VSWITCH,GEVALS,
- TLPROP,RLCPROP,FHVALS>{NODE} {
+ TLPROP,RLCPROP,FHVALS,DOUBLEVALUE>{NODE} {
     /* identify node */
     spice_lval.ident = strdup (spice_text);
+    if (yy_start_stack_ptr > 0 && top_state() == DOUBLEVALUE) {
+      pop_state();
+    }
     return Nodes;
 }
 
 <STARTUP,IVREF,DEVPROP,LREF,IGNORE,FUNREF,FILEREF,VREF,VSINGLE,
- ISWITCH,VSWITCH,GEVALS,SUBCKT,TLPROP,RLCPROP,FHVALS>{EOL} {
+ ISWITCH,VSWITCH,GEVALS,SUBCKT,TLPROP,RLCPROP,FHVALS,DOUBLEVALUE>{EOL} {
     /* detect end of line */
+    if (yy_start_stack_ptr > 0 && top_state() == DOUBLEVALUE) {
+      pop_state();
+    }
     BEGIN(STARTUP);
     return Eol;
 }

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -294,7 +294,7 @@ void environment::setValue (char * n, constant * value) {
 
 // Local macro definition to go through the list of equations.
 #define foreach_equation(eqn)                        \
-  for (assignment * (eqn) = A (equations);           \
+  for (assignment * eqn = A (equations);             \
        (eqn) != NULL; (eqn) = A ((eqn)->getNext ()))
 
 // Short helper macro.

--- a/src/equation.cpp
+++ b/src/equation.cpp
@@ -1401,7 +1401,7 @@ checker::~checker ()
 
 // Local macro definition to go through the list of equations.
 #define foreach_equation(eqn)                        \
-  for (assignment * (eqn) = A (equations);           \
+  for (assignment * eqn = A (equations);           \
        (eqn) != NULL; (eqn) = A ((eqn)->getNext ()))
 
 /* The function goes through the list of equations assigned to the
@@ -2187,6 +2187,7 @@ int solver::dataSize (constant * eqn)
         break;
     case TAG_MATVEC: // matrix vector
         size = eqn->getResult()->mv->getSize ();
+        break;
     default:
         size = 1;
     }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -76,14 +76,14 @@ using namespace fspecial;
 #define _ARES(idx) args->getResult(idx)
 #define _ARG(idx) args->get(idx)
 
-#define _D(var,idx) nr_double_t (var) = D (_ARES (idx));
-#define _BO(var,idx) bool (var) = B (_ARES (idx));
-#define _CX(var,idx) nr_complex_t * (var) = C (_ARES (idx));
-#define _V(var,idx) qucs::vector * (var) = V (_ARES (idx));
-#define _M(var,idx) matrix * (var) = M (_ARES (idx));
-#define _MV(var,idx) matvec * (var) = MV (_ARES (idx));
-#define _I(var,idx) int (var) = INT (_ARES (idx));
-#define _R(var,idx) range * (var) = RNG (_ARES (idx));
+#define _D(var,idx) nr_double_t var = D (_ARES (idx));
+#define _BO(var,idx) bool var = B (_ARES (idx));
+#define _CX(var,idx) nr_complex_t * var = C (_ARES (idx));
+#define _V(var,idx) qucs::vector * var = V (_ARES (idx));
+#define _M(var,idx) matrix * var = M (_ARES (idx));
+#define _MV(var,idx) matvec * var = MV (_ARES (idx));
+#define _I(var,idx) int var = INT (_ARES (idx));
+#define _R(var,idx) range * var = RNG (_ARES (idx));
 
 #define _ARR0(var) _R (var,0)
 #define _ARR1(var) _R (var,1)

--- a/src/hbsolver.cpp
+++ b/src/hbsolver.cpp
@@ -415,7 +415,7 @@ void hbsolver::collectFrequencies (void) {
 
   // build frequency dimension lengths
   ndfreqs = new int[dfreqs.size ()];
-  for (i = 0; i < dfreqs.size (); i++) {
+  for (i = 0; i < static_cast<int>(dfreqs.size ()); i++) {
     ndfreqs[i] = (n + 1) * 2;
   }
 
@@ -428,7 +428,7 @@ void hbsolver::collectFrequencies (void) {
 #endif /* HB_DEBUG */
 
   // build list of positive frequencies including DC
-  for (n = 0; n < negfreqs.size (); n++) {
+  for (n = 0; n < static_cast<int>(negfreqs.size ()); n++) {
     if ((f = negfreqs[n]) < 0.0) continue;
     rfreqs.push_back (f);
   }
@@ -576,7 +576,7 @@ void hbsolver::createMatrixLinearA (void) {
   A = new tmatrix<nr_complex_t> ((N + M) * lnfreqs);
 
   // through each frequency
-  for (int i = 0; i < rfreqs.size (); i++) {
+  for (int i = 0; i < static_cast<int>(rfreqs.size ()); i++) {
     freq = rfreqs[i];
     // calculate components' MNA matrix for the given frequency
     for (auto *lc : lincircuits)
@@ -882,7 +882,7 @@ void hbsolver::calcConstantCurrent (void) {
     circuit * vs = *it;
     vs->initHB ();
     vs->setVoltageSource (0);
-    for (int f = 0; f < rfreqs.size (); f++) { // for each frequency
+    for (int f = 0; f < static_cast<int>(rfreqs.size ()); f++) { // for each frequency
       nr_double_t freq = rfreqs[f];
       vs->calcHB (freq);
       VC (vsrc * lnfreqs + f) = vs->getE (VSRC_1);

--- a/src/interface/e_trsolver.cpp
+++ b/src/interface/e_trsolver.cpp
@@ -371,7 +371,7 @@ void e_trsolver::printx()
 {
     char buf [1024];
 
-    for (int r = 0; r < x->size(); r++) {
+    for (int r = 0; r < static_cast<int>(x->size()); r++) {
         buf[0] = '\0';
         //sprintf (buf, "%+.2e%+.2ei", (double) real (x->get (r)), (double) imag (x->get (r)));
 
@@ -552,7 +552,7 @@ void e_trsolver::acceptstep_sync()
 
 /* This function tries to adapt the current time-step according to the
    global truncation error. */
-void e_trsolver::adjustDelta_sync (nr_double_t t)
+void e_trsolver::adjustDelta_sync (nr_double_t /* t */)
 {
     deltaOld = delta;
 
@@ -830,7 +830,7 @@ void e_trsolver::copySolution (tvector<nr_double_t> * src[8], tvector<nr_double_
         // check sizes are the same
         assert (src[i]->size () == dest[i]->size ());
         // copy over the data values
-        for (int j = 0; j < src[i]->size (); j++)
+        for (int j = 0; j < static_cast<int>(src[i]->size ()); j++)
         {
             dest[i]->set (j, src[i]->get (j));
         }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -454,7 +454,7 @@ void module::registerDynamicModules (char *proj, std::list<std::string> modlist)
 */
 
   fprintf(stdout,"project location: %s\n", proj);
-  fprintf(stdout,"modules to load: %lu\n", modlist.size());
+  fprintf(stdout,"modules to load: %u\n", modlist.size());
 
   std::list<std::string>::iterator it;
   for (it=modlist.begin(); it!=modlist.end(); ++it) {

--- a/src/nasolver.cpp
+++ b/src/nasolver.cpp
@@ -250,7 +250,7 @@ void nasolver<nr_type_t>::applyNodeset (bool nokeep)
     if (x == NULL || nlist == NULL) return;
 
     // set each solution to zero
-    if (nokeep) for (int i = 0; i < x->size (); i++) x->set (i, 0);
+    if (nokeep) for (int i = 0; i < static_cast<int>(x->size ()); i++) x->set (i, 0);
 
     // then apply the nodeset itself
     for (nodeset * n = subnet->getNodeset (); n; n = n->getNext ())

--- a/src/parse_citi.ypp
+++ b/src/parse_citi.ypp
@@ -49,7 +49,7 @@ using namespace qucs;
 
 %}
 
-%name-prefix "citi_"
+%define api.prefix {citi_}
 
 %token InvalidCharacter
 %token Float

--- a/src/parse_csv.ypp
+++ b/src/parse_csv.ypp
@@ -49,9 +49,8 @@ using namespace qucs;
 
 %}
 
-%name-prefix "csv_"
+%define api.prefix {csv_}
 
-%token InvalidCharacter
 %token Float
 %token Identifier
 %token Eol
@@ -66,7 +65,7 @@ using namespace qucs;
 %type <list> HeaderList HeaderLine
 %type <ident> Identifier Header
 %type <f> Float
-%type <v> DataLine DataSet DataList
+%type <v> DataSet DataList
 
 %%
 
@@ -89,10 +88,16 @@ Header:
   }
 ;
 
-HeaderList: /* nothing */ { $$ = NULL; }
+HeaderList:
+    Header {
+    $$ = new strlist ();
+    $$->add ($1);
+    free ($1);
+  }
   | Header HeaderList {
-    if ($2 == NULL) $2 = new strlist ();
-    $2->add ($1);
+    strlist* item = new strlist ();
+    item->add ($1);
+    $2->add (item);
     $$ = $2;
     free ($1);
   }
@@ -108,11 +113,11 @@ HeaderLine: /* header line */
 ;
 
 DataSet: /* nothing */ { $$ = NULL; }
-  | DataLine Eol DataSet { /* append vector lines */
+  | DataList Eol DataSet { /* append vector lines */
     $1->setNext ($3);
     $$ = $1;
   }
-  | DataLine { /* last line, no trailing end-of-line */
+  | DataList { /* last line, no trailing end-of-line */
     $$ = $1;
   }
   | Eol DataSet { /* skip this line */
@@ -120,10 +125,12 @@ DataSet: /* nothing */ { $$ = NULL; }
   }
 ;
 
-DataLine: DataList
-;
-
-DataList: /* nothing */ { $$ = NULL; }
+DataList:
+    Float {
+    if ($$ == NULL) $$ = new vector ();
+    $$ = new vector ();
+    $$->add ($1);
+  }
   | Float DataList {
     if ($2 == NULL) $2 = new vector ();
     $2->add ($1);

--- a/src/parse_dataset.ypp
+++ b/src/parse_dataset.ypp
@@ -49,7 +49,7 @@ using namespace qucs;
 
 %}
 
-%name-prefix "dataset_"
+%define api.prefix {dataset_}
 
 %token InvalidCharacter
 %token Identifier

--- a/src/parse_mdl.ypp
+++ b/src/parse_mdl.ypp
@@ -49,7 +49,7 @@ using namespace qucs;
 
 %}
 
-%name-prefix "mdl_"
+%define api.prefix {mdl_}
 
 %token LINK
 %token Identifier

--- a/src/parse_netlist.ypp
+++ b/src/parse_netlist.ypp
@@ -46,7 +46,7 @@ using namespace qucs;
 
 %}
 
-%name-prefix "netlist_"
+%define api.prefix {netlist_}
 
 %token InvalidCharacter
 %token Identifier
@@ -62,7 +62,6 @@ using namespace qucs;
 %token Character
 %token STRING
 
-%right '='
 %right '?' ':'
 %left  Or
 %left  And
@@ -70,9 +69,9 @@ using namespace qucs;
 %left  Less Greater LessOrEqual GreaterOrEqual
 %left  '-' '+'
 %left  '*' '/' '%'
-%right Not
-%left  NEG     /* unary negation */
-%left  POS     /* unary non-negation */
+%precedence  Not
+%precedence  NEG     /* unary negation */
+%precedence  POS     /* unary non-negation */
 %right '^'
 
 %union {

--- a/src/parse_touchstone.ypp
+++ b/src/parse_touchstone.ypp
@@ -49,7 +49,7 @@ using namespace qucs;
 
 %}
 
-%name-prefix "touchstone_"
+%define api.prefix {touchstone_}
 
 %token InvalidCharacter
 %token Float
@@ -101,15 +101,6 @@ Dataset: /* nothing */ { }
     if (touchstone_line)
       touchstone_line->setNext($2);
     touchstone_line = $2;
-  }
-  | Dataset DataLine { /* last line, no trailing end-of-line */
-    if (!touchstone_vector)
-      touchstone_vector = $2; /* save first vector location */
-    if (touchstone_line)
-      touchstone_line->setNext($2);
-    touchstone_line = $2;
-    logprint (LOG_ERROR, "line %d: no trailing end-of-line found, "
-	      "continuing...\n", touchstone_lineno);
   }
   | Dataset Eol { /* skip this line */ }
 ;

--- a/src/parse_zvr.ypp
+++ b/src/parse_zvr.ypp
@@ -49,7 +49,7 @@ using namespace qucs;
 
 %}
 
-%name-prefix "zvr_"
+%define api.prefix {zvr_}
 
 %token ZVR
 %token Version

--- a/src/scan_csv.lpp
+++ b/src/scan_csv.lpp
@@ -103,7 +103,7 @@ SPACE    [ \t]
     logprint (LOG_ERROR,
 	      "line %d: syntax error, unrecognized character: `%s'\n",
 	      csv_lineno, csv_text);
-    return InvalidCharacter;
+    REJECT;
   }
 
 <COMMENT>.     { /* skip any character in here */ }

--- a/src/spline.cpp
+++ b/src/spline.cpp
@@ -119,7 +119,7 @@ void spline::vectors (std::vector<nr_double_t> y, std::vector<nr_double_t> t) {
 // Pass interpolation datapoints as tvectors.
 void spline::vectors (tvector<nr_double_t> y, tvector<nr_double_t> t) {
   int i = t.size ();
-  assert (y.size () == i && i >= 3);
+  assert (static_cast<int>(y.size ()) == i && i >= 3);
 
   // create local copy of f(x)
   realloc (i);

--- a/src/strlist.cpp
+++ b/src/strlist.cpp
@@ -192,6 +192,15 @@ char * strlist::toString (const char * concat) {
   return txt ? txt : (char *) "";
 }
 
+strlist& strlist::operator=(const strlist& rhs)
+{
+  struct strlist_t * s;
+  root = NULL;
+  txt = NULL;
+  for (s = rhs.root; s != NULL; s = s->next) append (s->str);
+  return *this;
+}
+
 // Constructor for string list iterator.
 strlistiterator::strlistiterator (strlist & s) {
   _strlist = &s;

--- a/src/strlist.h
+++ b/src/strlist.h
@@ -55,6 +55,7 @@ class strlist
   static strlist * join (strlist *, strlist *);
   void del (strlist *);
   char * toString (const char * concat = " ");
+  strlist& operator=(const strlist& rhs);
 
  private:
   struct strlist_t * root;

--- a/src/tmatrix.cpp
+++ b/src/tmatrix.cpp
@@ -57,7 +57,7 @@ tmatrix<nr_type_t>::tmatrix (int s)  {
   rows = cols = s;
   if (s > 0) {
     data = new nr_type_t[s * s];
-    memset (data, 0, sizeof (nr_type_t) * s * s);
+    memset (static_cast<void*>(data), 0, sizeof (nr_type_t) * s * s);
   }
   else data = NULL;
 }
@@ -70,7 +70,7 @@ tmatrix<nr_type_t>::tmatrix (int r, int c)  {
   cols = c;
   if (r > 0 && c > 0) {
     data = new nr_type_t[r * c];
-    memset (data, 0, sizeof (nr_type_t) * r * c);
+    memset (static_cast<void*>(data), 0, sizeof (nr_type_t) * r * c);
   }
   else data = NULL;
 }
@@ -294,7 +294,7 @@ tmatrix<nr_type_t> operator * (tmatrix<nr_type_t> a, tmatrix<nr_type_t> b) {
 // Multiplication of matrix and vector.
 template <class nr_type_t>
 tvector<nr_type_t> operator * (tmatrix<nr_type_t> a, tvector<nr_type_t> b) {
-  assert (a.getCols () == b.size ());
+  assert (a.getCols () == static_cast<int>(b.size ()));
   int r, c, n = a.getCols ();
   nr_type_t z;
   tvector<nr_type_t> res (n);
@@ -309,7 +309,7 @@ tvector<nr_type_t> operator * (tmatrix<nr_type_t> a, tvector<nr_type_t> b) {
 // Multiplication of vector (transposed) and matrix.
 template <class nr_type_t>
 tvector<nr_type_t> operator * (tvector<nr_type_t> a, tmatrix<nr_type_t> b) {
-  assert (a.size () == b.getRows ());
+  assert (static_cast<int>(a.size ()) == b.getRows ());
   int r, c, n = b.getRows ();
   nr_type_t z;
   tvector<nr_type_t> res (n);

--- a/src/tvector.cpp
+++ b/src/tvector.cpp
@@ -180,7 +180,7 @@ template <class nr_type_t>
 nr_type_t scalar (tvector<nr_type_t> a, tvector<nr_type_t> b) {
   assert (a.size () == b.size ());
   nr_type_t n = 0;
-  for (int i = 0; i < a.size (); i++) n += a.get (i) * b.get (i);
+  for (int i = 0; i < static_cast<int>(a.size ()); i++) n += a.get (i) * b.get (i);
   return n;
 }
 
@@ -195,7 +195,7 @@ tvector<nr_type_t> tvector<nr_type_t>::operator = (const nr_type_t val) {
 template <class nr_type_t>
 nr_type_t sum (tvector<nr_type_t> a) {
   nr_type_t res = 0;
-  for (int i = 0; i < a.size (); i++) res += a.get (i);
+  for (int i = 0; i < static_cast<int>(a.size ()); i++) res += a.get (i);
   return res;
 }
 
@@ -249,7 +249,7 @@ nr_double_t norm (tvector<nr_type_t> a) {
   return n;
 #else
   nr_double_t scale = 0, n = 1, x, ax;
-  for (int i = 0; i < a.size (); i++) {
+  for (int i = 0; i < static_cast<int>(a.size ()); i++) {
     if ((x = real (a (i))) != 0) {
       ax = fabs (x);
       if (scale < ax) {
@@ -283,7 +283,7 @@ nr_double_t norm (tvector<nr_type_t> a) {
 template <class nr_type_t>
 nr_double_t maxnorm (tvector<nr_type_t> a) {
   nr_double_t nMax = 0, n;
-  for (int i = 0; i < a.size (); i++) {
+  for (int i = 0; i < static_cast<int>(a.size ()); i++) {
     n = norm (a.get (i));
     if (n > nMax) nMax = n;
   }

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -323,7 +323,12 @@ vector xhypot (vector v1, vector v2) {
   vector res (len);
   for (j = i = n = 0; n < len; n++) {
     res (n) = xhypot (v1 (i), v2 (j));
-    if (++i >= len1) i = 0; if (++j >= len2) j = 0;
+    if (++i >= len1) {
+      i = 0;
+    }
+    if (++j >= len2) {
+      j = 0;
+    }
   }
   return res;
 }
@@ -449,7 +454,12 @@ vector pow (vector v1, vector v2) {
   vector res (len);
   for (j = i = n = 0; n < len; n++) {
     res (n) = pow (v1 (i), v2 (j));
-    if (++i >= len1) i = 0; if (++j >= len2) j = 0;
+    if (++i >= len1) {
+      i = 0;
+    }
+    if (++j >= len2) {
+      j = 0;
+    }
   }
   return res;
 }
@@ -903,7 +913,8 @@ vector operator%(vector v1, vector v2) {
   vector res (len);
   for (j = i = n = 0; n < len; n++) {
     res (n) = v1 (i) % v2 (j);
-    if (++i >= len1) i = 0;  if (++j >= len2) j = 0;
+    if (++i >= len1) i = 0;
+    if (++j >= len2) j = 0;
   }
   return res;
 }
@@ -1168,7 +1179,12 @@ vector polar (vector a, vector p) {
   vector res (len);
   for (j = i = n = 0; n < len; n++) {
     res (n) = qucs::polar (a (i), p (j));
-    if (++i >= len1) i = 0;  if (++j >= len2) j = 0;
+    if (++i >= len1) {
+      i = 0;
+    }
+    if (++j >= len2) {
+      j = 0;
+    }
   }
   return res;
 }
@@ -1199,7 +1215,12 @@ vector atan2 (vector y, vector x) {
   vector res (len);
   for (j = i = n = 0; n < len; n++) {
     res (n) = atan2 (y (i), x (j));
-    if (++i >= len1) i = 0; if (++j >= len2) j = 0;
+    if (++i >= len1) {
+      i = 0;
+    }
+    if (++j >= len2) {
+      j = 0;
+    }
   }
   return res;
 }

--- a/tests/basic/components/spfile/bjt.cir
+++ b/tests/basic/components/spfile/bjt.cir
@@ -1,0 +1,29 @@
+.title dual rc ladder
+* file name rcrcac.cir
+*R1 int in 10k
+*V1 in 0 dc 0 ac 1 PULSE (0 5 1u 1u 1u 1 1)
+*R2 out int 1k
+*C1 int 0 1u
+*C2 out 0 100n
+
+Q1 A B C BJTNAME
+Q2 20 21 22 NPN 1.0
+Q3 A B C BJTNAME 7.0 8.0
+Q4 1 2 3 BJTNAME
+Q5 20 20 97 PNP
+Q6 21 21 22 A B NPN 1.0
+Q7 A B C D BJTNAME
+
+.MODEL PNP PNP(BF=200 CJC=20pf CJE=20pf IS=1E-16)
+.MODEL NPN NPN(BF=200 CJC=20pf CJE=20pf IS=1E-16)
+.MODEL BJTNAME NPN(BF=200 CJC=20pf CJE=20pf IS=1E-16)
+
+.plot dc 1 2 3 4 5 6 7 8
+
+*.control
+*ac dec 10 1 100k
+*plot vdb(out)
+*plot ph(out)
+*.endc
+
+


### PR DESCRIPTION
-The lookahead-pattern for differentiate the 3-/4-/5-node spice-bjt
 erroneously contains newline. This causes read a spice bjt-line don't
 stop at new line and detect a 5-node bjt instead of 3-node bjt as
 happen for AD822X.cir of Opamp_AC_Tran.zip from the issue 967.
 This is fixed and tested against AD822X.cir. The critical lines from
 AD822X.cir are included in the bjt.cir qucsconv_rf testing example.

cherry-picked from 3c375fd3516263091ed308d461028889ff05757a:

Fix build issues
-fixed sprintf format buffer overflow warning: check_citi.cpp,
 check_mdl.cpp, check_spice.cpp
-fixed signed compare/expression warning: check_mdl.cpp, circuit.cpp,
 hbsolver.cpp, e_trsolver.cpp, nasolver.cpp, spline.cpp, tmatrix.cpp,
 tvector.cpp
-fixed clearing of non-trivial type via memset warning by static_cast:
 circuit.cpp, tmatrix.cpp
-fixed int-in-bool-context warning: thyristor.cpp
-fixed unnecessary parentheses warning: environment.cpp, equation.cpp,
 evaluate.cpp
-fixed case fallthrough warning: equation.cpp
-fixed unused parameter/variable warning: e_trsolver.cpp, real.cpp, qucs_action.cpp
-fixed infinite recursion warning: real.cpp, real.h
-fixed format type warning: module.cpp
-fixed depracated copy warning by adding assignment operator: strlist.cpp,
 strlist.h
-fixed misleading indentation warning: vector.cpp
-fixed deprecated yacc/bison name-prefix directive warning: parse_spice.ypp,
 parse_vcd.ypp, parse_citi.ypp, parse_csv.ypp, parse_dataset.ypp, parse_mdl.ypp
 parse_mdl.ypp parse_netlist.ypp, parse_touchstone.ypp parse_zvr.ypp
-fixed useless yacc/bison symbol definition: parse_vcd.ypp
-fixed shift/reduce-conflicts (sr) and reduce/reduce-conflicts (rr) of the spice-parser
 build by parse_spice.ypp and scan_spice.lpp:
   -sr-conflicts solved by introducing token/rule precedence
   -rr-conflicts solved by introducing token lookahead's in the spice scanner
   -verification of equalness of generated output from both the converter before and
    after the code change done with spice input bjt.cir done
-fixed shift/reduce-conflicts (sr) and reduce/reduce-conflicts (rr) of the csv-parser
 build by parse_csv.ypp and scan_csv.lpp:
   -sr/rr-conflicts solved by downsize and reorder grammatic rules
   -verification of equalness of generated output from both the converter before and
    after the code change done with csv input qucs_csv.csv done
-removed useless scanner token definition and replaced misleading operator assocativity
 with precedence: parse_netlist.ypp
-fixed shift/reduce-conflicts (sr) of the touchstone-parser build by parse_touchstone.ypp and
 scan_touchstonelpp:
   -sr conflicts solved by remove useless/redundant grammatic rules
   -verification of equalness of generated output from both the converter before and
    after the code change done with touchstone input R50C1pF.s1p done