### PR TITLE
Fix dataset conversion from Ngspice and DC sweep

### DIFF
--- a/src/scan_dataset.lpp
+++ b/src/scan_dataset.lpp
@@ -63,8 +63,8 @@ WS       [ \t\n\r]
 IDENT1   [a-zA-Z_][a-zA-Z0-9_]*
 IDENT2   [a-zA-Z_][a-zA-Z0-9_\[\],]*
 IDENT3   [a-zA-Z0-9_][a-zA-Z0-9_]*
-IDENT4   [vViI]\([a-zA-Z0-9_]*\)
-IDENT    {IDENT1}|{IDENT2}
+IDENT4   [vViI]\([a-zA-Z0-9_-]*\)
+IDENT    {IDENT1}|{IDENT2}|{IDENT4}
 PIDENT   {IDENT1}|{IDENT2}|{IDENT3}|{IDENT4}
 SIMPLEID {IDENT}
 POSTID   "."{PIDENT}


### PR DESCRIPTION
This patch fixes the error when trying to convert DC sweep data. The converter now can recognize variables containing `-` sign in the name. Here is an example of such dataset.

[6p41s_test.dat.ngspice.gz](https://github.com/user-attachments/files/18882758/6p41s_test.dat.ngspice.gz)
